### PR TITLE
Ensure sprite cannot spawn on initial user location

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -4,16 +4,17 @@ class Game extends Component {
   constructor(props) {
     super(props);
     const { boardSizeX, boardSizeY } = props;
-    this.spritesPos = this.generateSpritesPos(boardSizeX, boardSizeY);
+    const initialUserPos = {
+      x: Math.floor(boardSizeX / 2),
+      y: Math.floor(boardSizeY / 2)
+    };
+    this.spritesPos = this.generateSpritesPos(boardSizeX, boardSizeY, initialUserPos);
     this.moves = 0; // please check readme
     this.remainingSprites = boardSizeY;
     this.boardRef = createRef();
     // initially user is placed in center
     this.state = {
-      userPos: {
-        x: Math.floor(boardSizeX / 2),
-        y: Math.floor(boardSizeY / 2)
-      },
+      userPos: initialUserPos,
       hasFinished: false
     };
   }
@@ -29,11 +30,21 @@ class Game extends Component {
     }
   }
 
-  generateSpritesPos(boardSizeX, boardSizeY) {
+  generateSpritesPos(boardSizeX, boardSizeY, initialUserPos) {
+    const getRandomXPos = () => Math.floor(Math.random() * boardSizeX);
+
     const spritesPos = [];
     for (let i = 0; i < boardSizeY; i += 1) {
-      const spritePos = Math.floor(Math.random() * boardSizeX);
-      spritesPos.push(spritePos);
+      spritesPos.push(getRandomXPos());
+    }
+
+    // If there's a sprite on the initial user pos, move it
+    if (spritesPos[initialUserPos.y] === initialUserPos.x) {
+      let spritePos;
+      do {
+        spritePos = getRandomXPos();
+      } while (spritePos === initialUserPos.x);
+      spritesPos[initialUserPos.y] = spritePos;
     }
 
     // index is the row number and spritesPos[key] is the column number
@@ -213,7 +224,7 @@ class Game extends Component {
                 <strong data-testid="moveCounter">{this.moves}</strong>
               </p>
               <div className="gamepad">
-                <button 
+                <button
                 className="gamepad__control gamepad__control--up"
                 onClick={() => {
                   const event = { key: 'ArrowUp' };

--- a/src/tests/Game.test.js
+++ b/src/tests/Game.test.js
@@ -139,17 +139,20 @@ describe('Move counter', () => {
   });
 
   it('should not increase move counter, when there is no place to move left', () => {
-    const { getByTestId } = render(<Game boardSizeX={1} boardSizeY={2} />);
+    const { getByTestId } = render(<Game boardSizeX={2} boardSizeY={1} />);
     const board = getByTestId('game-table');
     fireEvent.keyDown(board, {
       key: 'ArrowLeft'
     });
+    fireEvent.keyDown(board, {
+      key: 'ArrowLeft'
+    });
     const moveCounter = getByTestId('moveCounter');
-    expect(Number(moveCounter.innerHTML)).toBe(0);
+    expect(Number(moveCounter.innerHTML)).toBe(1);
   });
 
   it('should not increase move counter, when there is no place to move to right', () => {
-    const { getByTestId } = render(<Game boardSizeX={1} boardSizeY={2} />);
+    const { getByTestId } = render(<Game boardSizeX={2} boardSizeY={1} />);
     const board = getByTestId('game-table');
     fireEvent.keyDown(board, {
       key: 'ArrowRight'
@@ -161,9 +164,6 @@ describe('Move counter', () => {
   it('should show the score after game end', () => {
     const { getByTestId } = render(<Game boardSizeX={2} boardSizeY={1} />);
     const board = getByTestId('game-table');
-
-    // because has-sprite can be on has-user tail, we have to move two directions, to get
-    // the sprite that starts on initial user position
     fireEvent.keyDown(board, {
       key: 'ArrowLeft'
     });


### PR DESCRIPTION
I also had to update a few tests to accommodate this change. Because a sprite cannot spawn under the user, `boardSizeX` can no longer be `1`.